### PR TITLE
add midi_processor submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "midi_processor"]
+	path = midi_processor
+	url = https://github.com/jason9693/midi-neural-processor.git


### PR DESCRIPTION
In upstream, midi_processor adds like: 
> ## Repository Setting
> 
> ``` sh
> $ git clone https://github.com/jason9693/MusicTransformer-tensorflow2.0.git
> $ cd MusicTransformer-tensorflow2.0
> $ git clone https://github.com/jason9693/midi-neural-processor.git
> $ mv midi-neural-processor midi_processor
> ```

This PR change it going to this submodule repository.